### PR TITLE
Feature/catch immediate error on spawn

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,10 +46,21 @@ Camera.prototype.getImageAsFile = function (options, filename, callback) {
             callback('filename property should be a string');
         }
 
-        var stream = raspistill(options).pipe(fs.createWriteStream(filename));
+        raspistill(options, function(err, stream) {
+            if (err) {
+                callback(err);
+                return;
+            }
 
-        stream.on('finish', function() {
-            callback(null);
+            stream.on('finish', function() {
+                callback(null);
+            });
+
+            stream.on('error', function(e) {
+                callback(e);
+            });
+
+            stream.pipe(fs.createWriteStream(filename));
         });
     } catch (error) {
         callback(error);

--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@ var opts = new Options();
 var raspistill = function(options, callback) {
     var args = opts.process(options);
 
-    var child = spawn('raspistill', args.concat(['-o',  '-'])
+    var child = spawn('raspistill', args.concat(['-o',  '-']))
         .on('error', function(error) {
             callback(error);
-        }));
+        });
 
     var stream = new Stream();
     child.stderr.on('data', stream.emit.bind(stream, 'error'));


### PR DESCRIPTION
I encountered an error using this package on a machine where the raspistill image was not installed. For some reason it threw the following error instead of delegating the spawn error to the stream:

```
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: spawn raspistill ENOENT
    at exports._errnoException (util.js:1007:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:182:32)
    at onErrorNT (internal/child_process.js:348:16)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

I think if an error is thrown immediately on spawn, and therefore no error handlers are attached yet, it will crash the parent process because it thinks the error will never get caught otherwise. Even though there's that error listener on line 22. It gets attached too late.

I've left it because we also want errors that happen after the stream is returned to be sent to the stream.

Lastly I've also modified the getImageAsFile function to use the new API and pass through the errors.

_I was not able to run the tests as I don't have a Pi hanging on my machine atm._ Can you run these and verify all is well with the world?
